### PR TITLE
Add SessionStart hook to run gh-setup-hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun x gh-setup-hooks",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Configure Claude Code to automatically run 'bun x gh-setup-hooks' when a session starts.
This ensures GitHub hooks are properly set up at the beginning of each session.