### PR TITLE
Add FileSystem Observer API support for automatic file change detection

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -214,6 +214,11 @@ body {
   color: var(--color-primary);
 }
 
+.live-updates-indicator {
+  color: var(--color-success);
+  font-size: 0.9em;
+}
+
 .file-list {
   flex: 1;
   overflow-y: auto;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2,7 +2,11 @@
  * UI Components and Interactions
  */
 
-import { fileSystemManager, FileSystemEntry } from './fileSystem';
+import {
+  fileSystemManager,
+  FileSystemEntry,
+  FileSystemChangeRecord,
+} from './fileSystem';
 import { preferencesManager, ToolName } from './preferences';
 import { aiManager, AVAILABLE_MODELS } from './ai';
 import { fileTools, setPermissionCallback } from './tools';
@@ -278,6 +282,12 @@ export class UIManager {
         return;
       }
 
+      // Set up file system observer callback BEFORE directory selection
+      // to avoid missing any early change events
+      fileSystemManager.setChangeCallback((changes) => {
+        this.handleFileSystemChanges(changes);
+      });
+
       const handle = await fileSystemManager.selectDirectory();
 
       // Verify permissions
@@ -287,17 +297,15 @@ export class UIManager {
         return;
       }
 
-      // Set up file system observer callback
-      fileSystemManager.setChangeCallback((changes) => {
-        this.handleFileSystemChanges(changes);
-      });
+      // Start observing AFTER permission verification
+      const observerStarted = await fileSystemManager.startObserving();
 
       // Display folder info
       let folderInfoHtml = `<strong>Selected folder:</strong> ${handle.name}`;
 
-      // Add observer status indicator
-      if (fileSystemManager.isObserverSupported()) {
-        folderInfoHtml += ' <span style="color: #4CAF50; font-size: 0.9em;">(Live updates enabled)</span>';
+      // Add observer status indicator only if observer actually started successfully
+      if (observerStarted && fileSystemManager.isObserving()) {
+        folderInfoHtml += ' <span class="live-updates-indicator">(Live updates enabled)</span>';
       }
 
       this.elements.folderInfo.innerHTML = folderInfoHtml;
@@ -328,12 +336,16 @@ export class UIManager {
   /**
    * Handle file system changes from the observer
    */
-  private async handleFileSystemChanges(changes: any[]): Promise<void> {
+  private async handleFileSystemChanges(changes: FileSystemChangeRecord[]): Promise<void> {
     console.log('UI: File system changes detected, refreshing file list');
 
-    // Show brief notification
-    const changeTypes = changes.map((c) => c.type).join(', ');
-    this.setStatus(`Files ${changeTypes} - refreshing...`, 'info');
+    // Show brief notification with improved grammar
+    const changeTypes = new Set(changes.map((c) => c.type));
+    const typeList = Array.from(changeTypes).join(', ');
+    const changeCount = changes.length;
+    const fileWord = changeCount === 1 ? 'file' : 'files';
+
+    this.setStatus(`Detected ${changeCount} ${fileWord} ${typeList} - refreshing...`, 'info');
 
     // Refresh the file list to reflect changes
     await this.refreshFileList();


### PR DESCRIPTION
Implements the FileSystem Observer API (Chrome 129+) to automatically detect
and respond to file system changes without polling.

Key features:
- Feature detection for FileSystemObserver API
- Automatic observation of selected directories (recursive)
- Real-time UI updates when files are added, modified, or deleted
- Graceful fallback when API is not supported
- Live update indicator in folder info when observer is active

Changes:
- fileSystem.ts: Add TypeScript declarations, observer lifecycle methods,
  and automatic cache updates based on change events
- ui.ts: Integrate observer callback, auto-refresh file list on changes,
  and show status notifications

The observer starts automatically when a directory is selected and stops
when the directory is deselected or app is reset.