### PR TITLE
Add permission checks for list_files and get_file_metadata tools

### DIFF
--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -24,7 +24,9 @@ export type ToolName =
   | 'move_file'
   | 'delete_file'
   | 'create_file'
-  | 'write_file';
+  | 'write_file'
+  | 'list_files'
+  | 'get_file_metadata';
 
 export interface ToolPermissions {
   open_file: PermissionLevel;
@@ -33,6 +35,8 @@ export interface ToolPermissions {
   delete_file: PermissionLevel;
   create_file: PermissionLevel;
   write_file: PermissionLevel;
+  list_files: PermissionLevel;
+  get_file_metadata: PermissionLevel;
 }
 
 export interface UserPreferences {
@@ -49,6 +53,8 @@ const DEFAULT_PERMISSIONS: ToolPermissions = {
   delete_file: 'ask',
   create_file: 'ask',
   write_file: 'ask',
+  list_files: 'ask',
+  get_file_metadata: 'ask',
 };
 
 const DEFAULT_PREFERENCES: UserPreferences = {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -254,6 +254,11 @@ export const listFilesTool = tool({
     'List all files in the directory. Returns an array of file paths. Use this to see what files are available before performing operations.',
   inputSchema: z.object({}),
   execute: async () => {
+    const allowed = await checkPermission('list_files', {});
+    if (!allowed) {
+      return { error: 'Permission denied to list files' };
+    }
+
     try {
       const entries = await fileSystemManager.listFiles();
       const files = entries.filter((e) => e.kind === 'file').map((e) => e.path);
@@ -279,6 +284,11 @@ export const getFileMetadataTool = tool({
     path: z.string().describe('The path to the file relative to the root directory'),
   }),
   execute: async (input) => {
+    const allowed = await checkPermission('get_file_metadata', { path: input.path });
+    if (!allowed) {
+      return { error: 'Permission denied to get file metadata' };
+    }
+
     try {
       const metadata = await fileSystemManager.getFileMetadata(input.path);
       return {


### PR DESCRIPTION
Enhanced the permission system to include the list_files and get_file_metadata tools:

- Added 'list_files' and 'get_file_metadata' to ToolName type
- Added both tools to ToolPermissions interface
- Added default 'ask' permissions for both tools in DEFAULT_PERMISSIONS
- Implemented permission checks in listFilesTool before executing
- Implemented permission checks in getFileMetadataTool before executing

This ensures consistent permission handling across all file operation tools,
giving users control over which operations the AI can perform.