### PR TITLE
Fix Cowork announcement link to use correct official URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
           <div class="info-content">
             <h3>About This Project</h3>
             <p>
-              Co-do was inspired by <a href="https://www.anthropic.com/news/cowork" target="_blank" rel="noopener noreferrer">Cowork by Anthropic</a>.
+              Co-do was inspired by <a href="https://claude.com/blog/cowork-research-preview" target="_blank" rel="noopener noreferrer">Cowork by Anthropic</a>.
               I wanted to explore the possibilities of file manipulation directly in the browser using modern web APIs.
             </p>
 


### PR DESCRIPTION
Updated the Cowork reference link from the incorrect
https://www.anthropic.com/news/cowork to the correct official
announcement at https://claude.com/blog/cowork-research-preview