### PR TITLE
Remove Gemini 3 preview models due to SDK compatibility issues

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -33,10 +33,9 @@ export const AVAILABLE_MODELS = {
     { id: 'gpt-4o', name: 'GPT-4o (Legacy)' },
   ],
   google: [
-    { id: 'gemini-3-flash-preview', name: 'Gemini 3 Flash (Preview)' },
-    { id: 'gemini-3-pro-preview', name: 'Gemini 3 Pro (Preview)' },
-    { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash' },
-    { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash (Retiring Soon)' },
+    { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash (Recommended)' },
+    { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro' },
+    { id: 'gemini-2.0-flash', name: 'Gemini 2.0 Flash' },
     { id: 'gemini-1.5-pro', name: 'Gemini 1.5 Pro (Legacy)' },
   ],
 };


### PR DESCRIPTION
Gemini 3 Flash and Pro preview models have known compatibility issues
with @ai-sdk/google when using tool calling. The SDK returns a
"specification version v1" error because these models aren't fully
supported yet. See https://github.com/vercel/ai/issues/11396 and
https://github.com/vercel/ai/issues/11413 for details.

This change:
- Removes gemini-3-flash-preview and gemini-3-pro-preview from model list
- Adds gemini-2.5-pro as a stable option
- Marks gemini-2.5-flash as the recommended Google model

The Gemini 3 models can be re-added once @ai-sdk/google is updated
to properly support them.