### PR TITLE
Disable dialogue animations on mobile

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -874,6 +874,14 @@ body {
   .status-bar {
     position: static;
   }
+
+  /* Disable animations on mobile for better performance and UX */
+  .tool-call,
+  .message,
+  .modal-content,
+  .permission-dialog {
+    animation: none !important;
+  }
 }
 
 /* Info Modal Content */


### PR DESCRIPTION
Remove all slide-in animations for tool calls, messages, modals, and permission dialogs on mobile devices (≤768px). Dialogues now appear instantly for better mobile UX.