### PR TITLE
Fix contrast issue in data sharing notice

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1113,6 +1113,7 @@ body {
 
 .warning-box.critical li {
   margin: 0.25rem 0;
+  color: #5D4037;
 }
 
 .warning-box.critical .warning-emphasis {


### PR DESCRIPTION
- Add explicit color for list items in critical warning box
- Ensures list item text has proper contrast against light background
- Dark mode already had correct colors defined