### PR TITLE
Modernize dialog implementation with HTML element

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,8 +112,7 @@
     </main>
 
     <!-- Settings Modal -->
-    <div id="settings-modal" class="modal" hidden role="dialog" aria-modal="true" aria-labelledby="settings-modal-title">
-      <div class="modal-overlay"></div>
+    <dialog id="settings-modal" class="modal" aria-labelledby="settings-modal-title">
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="settings-modal-title">AI Provider Settings</h2>
@@ -142,11 +141,10 @@
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
 
     <!-- Add/Edit Provider Modal -->
-    <div id="provider-edit-modal" class="modal" hidden role="dialog" aria-modal="true" aria-labelledby="provider-edit-modal-title">
-      <div class="modal-overlay"></div>
+    <dialog id="provider-edit-modal" class="modal" aria-labelledby="provider-edit-modal-title">
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="provider-edit-modal-title">Add Provider</h2>
@@ -199,11 +197,10 @@
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
 
     <!-- Tool Permissions Modal -->
-    <div id="tools-modal" class="modal" hidden role="dialog" aria-modal="true" aria-labelledby="tools-modal-title">
-      <div class="modal-overlay"></div>
+    <dialog id="tools-modal" class="modal" aria-labelledby="tools-modal-title">
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="tools-modal-title">Tool Permissions</h2>
@@ -267,11 +264,10 @@
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
 
     <!-- Info Modal -->
-    <div id="info-modal" class="modal" hidden role="dialog" aria-modal="true" aria-labelledby="info-modal-title">
-      <div class="modal-overlay"></div>
+    <dialog id="info-modal" class="modal" aria-labelledby="info-modal-title">
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="info-modal-title">About Co-do</h2>
@@ -330,12 +326,11 @@
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
 
     <!-- Data Sharing Warning Modal -->
     <!-- Note: This modal intentionally omits a close (X) button to ensure users explicitly acknowledge or cancel the warning -->
-    <div id="data-share-modal" class="modal" hidden role="dialog" aria-modal="true" aria-labelledby="data-share-modal-title">
-      <div class="modal-overlay"></div>
+    <dialog id="data-share-modal" class="modal no-escape" aria-labelledby="data-share-modal-title">
       <div class="modal-content">
         <div class="modal-header">
           <h2 id="data-share-modal-title">Important: Data Sharing Notice</h2>
@@ -373,7 +368,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
   </div>
 
   <!-- Toast Notifications Container -->

--- a/src/styles.css
+++ b/src/styles.css
@@ -502,11 +502,24 @@ body {
   transform: none;
 }
 
-/* Modal */
-.modal {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
+/* Modal (using native dialog element) */
+dialog.modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+  max-width: none;
+  max-height: none;
+  width: auto;
+  height: auto;
+  overflow: visible;
+}
+
+dialog.modal::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+dialog.modal[open] {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -520,17 +533,6 @@ body {
   to {
     opacity: 1;
   }
-}
-
-.modal[hidden] {
-  display: none;
-}
-
-.modal-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(2px);
 }
 
 .modal-content {
@@ -691,19 +693,23 @@ body {
   border-color: var(--color-primary);
 }
 
-/* Permission Dialog */
-.permission-dialog {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+/* Permission Dialog (using native dialog element) */
+dialog.permission-dialog {
+  border: none;
   background: var(--color-surface);
   padding: var(--spacing-xl);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-xl);
-  z-index: 1001;
   max-width: 500px;
   width: 90%;
+}
+
+dialog.permission-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+dialog.permission-dialog[open] {
   animation: modalSlideIn 0.3s ease;
 }
 
@@ -777,16 +783,7 @@ body {
   font-size: 0.8125rem;
 }
 
-.dialog-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(2px);
-  z-index: 1000;
-}
+/* .dialog-overlay is no longer needed - using native dialog::backdrop instead */
 
 /* Sidebar Overlay (for mobile) */
 .sidebar-overlay {
@@ -879,7 +876,8 @@ body {
   .tool-call,
   .message,
   .modal-content,
-  .permission-dialog {
+  dialog.modal[open],
+  dialog.permission-dialog[open] {
     animation: none !important;
   }
 }


### PR DESCRIPTION
Replace custom modal div implementation with native HTML <dialog> elements:
- Convert all modal divs to <dialog> elements in index.html
- Update ui.ts to use showModal() and close() methods
- Use native ::backdrop pseudo-element instead of manual overlay divs
- Handle escape key via dialog's native cancel event
- Convert dynamically created permission dialog to use <dialog>
- Remove unused .dialog-overlay CSS class