### PR TITLE
Improve tool call results display

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -448,10 +448,7 @@ body {
   transition: transform 0.2s ease;
 }
 
-/* Expanded state */
-.tool-activity-group.expanded .tool-activity-toggle {
-  transform: rotate(180deg);
-}
+/* Expanded state - no transform needed since JS changes text content */
 
 /* Collapsible content */
 .tool-activity-content {
@@ -461,7 +458,8 @@ body {
 }
 
 .tool-activity-group.expanded .tool-activity-content {
-  max-height: 2000px;
+  max-height: 70vh;
+  overflow-y: auto;
   transition: max-height 0.5s ease-in;
 }
 
@@ -1238,11 +1236,11 @@ body {
   }
 
   .tool-item-status.pending {
-    background: #1E5799;
+    background: #0B3A6E;
   }
 
   .tool-item-status.completed {
-    background: #2E7D32;
+    background: #1B5E20;
   }
 
   .tool-item-args,


### PR DESCRIPTION
- Group tool calls into collapsible "activity" section during AI responses
- Show summary header "Using X tools..." that can be expanded/collapsed
- Display individual tool calls with status badges (calling.../done)
- Add expandable details sections for arguments and results
- Truncate large JSON payloads to prevent UI clutter
- Support dark mode for new components
- Keep actual AI response prominent while tool activity is minimized

This improves UX by making the AI's actual response more visible while still allowing users to inspect tool activity when needed.