### PR TITLE
Add summary view for multiple tool messages

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -976,6 +976,78 @@ dialog.permission-dialog[open] {
   font-size: 0.8125rem;
 }
 
+/* Batch Permission Dialog */
+.batch-permission-dialog {
+  max-width: 600px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.batch-tool-list {
+  max-height: 300px;
+  overflow-y: auto;
+  margin-bottom: var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background);
+}
+
+.batch-tool-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.batch-tool-item:last-child {
+  border-bottom: none;
+}
+
+.batch-tool-item .tool-call {
+  flex: 1;
+  margin: 0;
+  animation: none;
+}
+
+.batch-tool-checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding-top: var(--spacing-xs);
+}
+
+.batch-tool-checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--color-primary);
+}
+
+.batch-selection-controls {
+  display: flex;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
+}
+
+.batch-selection-controls button {
+  padding: var(--spacing-xs) var(--spacing-md);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.batch-selection-controls button:hover {
+  background: var(--color-border);
+  color: var(--color-text-primary);
+}
+
 /* .dialog-overlay is no longer needed - using native dialog::backdrop instead */
 
 /* Sidebar Overlay (for mobile) */
@@ -1071,8 +1143,23 @@ dialog.permission-dialog[open] {
   .message,
   .modal-content,
   dialog.modal[open],
-  dialog.permission-dialog[open] {
+  dialog.permission-dialog[open],
+  dialog.batch-permission-dialog[open] {
     animation: none !important;
+  }
+
+  /* Batch permission dialog mobile adjustments */
+  .batch-permission-dialog {
+    max-height: 90vh;
+    width: 95%;
+  }
+
+  .batch-tool-list {
+    max-height: 200px;
+  }
+
+  .batch-selection-controls {
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
When the AI makes multiple tool calls simultaneously, they are now batched into a single permission dialog using native <dialog> element. Users can review all pending actions at once, selectively approve/deny individual actions with checkboxes, or use "Select All"/"Select None" buttons for quick selection. Single tool calls still use the original simpler dialog.

Updated to use native <dialog> element consistent with PR #35.