### PR TITLE
Add permissions UI for file tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,13 @@ When building this project:
    - Permission denial scenarios
    - Secure file operations
 
-4. **Collaboration Features**: When implementing Cowork-like functionality, consider:
+4. **Adding New Tools**: When creating a new AI tool in `src/tools.ts`, you must also:
+   - Add the tool name to the `ToolName` type in `src/preferences.ts`
+   - Add a default permission entry in `DEFAULT_TOOL_PERMISSIONS` in `src/preferences.ts`
+   - Add a corresponding permission UI element in `index.html` inside the `#tool-permissions` container
+   - Use the `checkPermission()` function in the tool's execute function to enforce permissions
+
+5. **Collaboration Features**: When implementing Cowork-like functionality, consider:
    - Real-time synchronization patterns
    - Conflict resolution for concurrent edits
    - Presence indicators for collaborators

--- a/index.html
+++ b/index.html
@@ -264,6 +264,54 @@
                 <option value="never">Never Allow</option>
               </select>
             </div>
+            <div class="permission-item">
+              <span class="tool-name">List Files</span>
+              <select class="permission-select" data-tool="list_files">
+                <option value="always">Always Allow</option>
+                <option value="ask" selected>Ask Each Time</option>
+                <option value="never">Never Allow</option>
+              </select>
+            </div>
+            <div class="permission-item">
+              <span class="tool-name">Get File Metadata</span>
+              <select class="permission-select" data-tool="get_file_metadata">
+                <option value="always">Always Allow</option>
+                <option value="ask" selected>Ask Each Time</option>
+                <option value="never">Never Allow</option>
+              </select>
+            </div>
+            <div class="permission-item">
+              <span class="tool-name">Cat (Display File)</span>
+              <select class="permission-select" data-tool="cat">
+                <option value="always">Always Allow</option>
+                <option value="ask" selected>Ask Each Time</option>
+                <option value="never">Never Allow</option>
+              </select>
+            </div>
+            <div class="permission-item">
+              <span class="tool-name">Grep (Search Files)</span>
+              <select class="permission-select" data-tool="grep">
+                <option value="always">Always Allow</option>
+                <option value="ask" selected>Ask Each Time</option>
+                <option value="never">Never Allow</option>
+              </select>
+            </div>
+            <div class="permission-item">
+              <span class="tool-name">Head (First Lines)</span>
+              <select class="permission-select" data-tool="head_file">
+                <option value="always">Always Allow</option>
+                <option value="ask" selected>Ask Each Time</option>
+                <option value="never">Never Allow</option>
+              </select>
+            </div>
+            <div class="permission-item">
+              <span class="tool-name">Tail (Last Lines)</span>
+              <select class="permission-select" data-tool="tail_file">
+                <option value="always">Always Allow</option>
+                <option value="ask" selected>Ask Each Time</option>
+                <option value="never">Never Allow</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Add permission controls for list_files, get_file_metadata, cat, grep, head_file, and tail_file tools in the Tool Permissions modal
- Update CLAUDE.md with requirements for adding tool permissions when creating new AI tools