### PR TITLE
Update service worker file

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,29 +1,15 @@
 // Service Worker for Co-do PWA
-// Update version to force cache refresh on new deployments
-const CACHE_VERSION = '1.0.3'; // Increment this on each deployment
-const CACHE_NAME = `co-do-v${CACHE_VERSION}`;
+// Uses network-first strategy with cache fallback for offline support
+// Update detection is handled by version.json checking in main.ts
+const CACHE_NAME = 'co-do-cache';
 const BASE_PATH = '/Co-do/';
 
-// Assets to cache on install
-const STATIC_ASSETS = [
-  BASE_PATH,
-  `${BASE_PATH}index.html`,
-  // Note: Vite generates hashed filenames in production
-  // These will be added dynamically during the first navigation
-];
-
-// Install event - cache static assets
-self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      return cache.addAll(STATIC_ASSETS);
-    })
-  );
-  // Don't skip waiting automatically - wait for user confirmation
-  // This prevents forced reloads when user cancels the update prompt
+// Install event - skip waiting to activate immediately
+self.addEventListener('install', () => {
+  self.skipWaiting();
 });
 
-// Activate event - clean up old caches
+// Activate event - take control and clean up old caches
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys().then((cacheNames) => {
@@ -34,14 +20,19 @@ self.addEventListener('activate', (event) => {
       );
     })
   );
-  // Take control immediately
   return self.clients.claim();
 });
 
-// Fetch event - serve from cache, fallback to network
+// Fetch event - network-first with cache fallback
 self.addEventListener('fetch', (event) => {
   const { request } = event;
   const url = new URL(request.url);
+
+  // Never cache version.json - always fetch from network
+  if (url.pathname.endsWith('version.json')) {
+    event.respondWith(fetch(request));
+    return;
+  }
 
   // Don't cache API requests to AI providers
   if (
@@ -49,74 +40,52 @@ self.addEventListener('fetch', (event) => {
     url.hostname === 'api.openai.com' ||
     url.hostname === 'generativelanguage.googleapis.com'
   ) {
-    // Network only for API requests with error handling
     event.respondWith(
       fetch(request).catch((error) => {
         console.error('[Service Worker] AI API fetch failed:', error);
-        // Re-throw to let the application handle the error
         throw error;
       })
     );
     return;
   }
 
-  // For same-origin requests, use stale-while-revalidate strategy
-  // This provides fast loads while ensuring background updates
+  // For same-origin requests, use network-first with cache fallback
   if (url.origin === location.origin) {
     event.respondWith(
-      caches.match(request).then((cachedResponse) => {
-        // Fetch from network in background to update cache
-        const fetchPromise = fetch(request)
-          .then((response) => {
-            // Don't cache non-successful responses
-            if (!response || response.status !== 200 || response.type !== 'basic') {
-              return response;
-            }
-
-            // Clone the response
+      fetch(request)
+        .then((response) => {
+          // Cache successful responses
+          if (response && response.status === 200 && response.type === 'basic') {
             const responseToCache = response.clone();
-
-            // Update cache in background
             caches
               .open(CACHE_NAME)
-              .then((cache) => {
-                return cache.put(request, responseToCache);
-              })
+              .then((cache) => cache.put(request, responseToCache))
               .catch((error) => {
-                // Log cache failures (e.g., storage quota exceeded)
                 console.error('[Service Worker] Failed to cache response:', error);
               });
-
-            return response;
-          })
-          .catch((error) => {
-            // On network failure, log but don't throw if we have cache
-            console.log('[Service Worker] Network fetch failed:', error);
-
-            // For navigation requests without cache, serve the app shell
-            if (!cachedResponse && request.mode === 'navigate') {
+          }
+          return response;
+        })
+        .catch((error) => {
+          console.log('[Service Worker] Network fetch failed, trying cache:', error);
+          return caches.match(request).then((cachedResponse) => {
+            if (cachedResponse) {
+              return cachedResponse;
+            }
+            // For navigation requests, try the app shell
+            if (request.mode === 'navigate') {
               return caches.match(`${BASE_PATH}index.html`);
             }
-
-            // If no cached response, throw the error
-            if (!cachedResponse) {
-              throw error;
-            }
-
-            return cachedResponse;
+            throw error;
           });
-
-        // Return cached response immediately if available, otherwise wait for network
-        return cachedResponse || fetchPromise;
-      })
+        })
     );
     return;
   }
 
-  // For cross-origin requests, just fetch with error handling
+  // For cross-origin requests, just fetch
   event.respondWith(
     fetch(request).catch((error) => {
-      // Log the error for debugging purposes and provide a fallback response
       console.error('[Service Worker] Cross-origin fetch failed:', error);
       return new Response('Network error while fetching resource.', {
         status: 504,
@@ -124,11 +93,4 @@ self.addEventListener('fetch', (event) => {
       });
     })
   );
-});
-
-// Handle messages from clients
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
-  }
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,112 @@ import './styles.css';
 import { UIManager } from './ui';
 import { preferencesManager } from './preferences';
 
+// Version checking constants
+const VERSION_STORAGE_KEY = 'co-do-app-version';
+const VERSION_CHECK_INTERVAL = 60000; // 60 seconds
+
+interface VersionInfo {
+  version: string;
+  buildTime: string;
+}
+
+/**
+ * Fetches the current version from the server
+ * Uses cache-busting to ensure we always get the latest version
+ */
+async function fetchVersion(): Promise<VersionInfo | null> {
+  try {
+    const response = await fetch(
+      `${import.meta.env.BASE_URL}version.json?t=${Date.now()}`,
+      {
+        cache: 'no-store',
+      }
+    );
+    if (!response.ok) {
+      console.warn('Failed to fetch version.json:', response.status);
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    console.warn('Error fetching version:', error);
+    return null;
+  }
+}
+
+/**
+ * Shows the update notification to the user
+ */
+function showUpdateNotification(): void {
+  const notification = document.getElementById('update-notification');
+  const reloadBtn = document.getElementById('update-reload-btn');
+  const dismissBtn = document.getElementById('update-dismiss-btn');
+
+  if (notification && reloadBtn && dismissBtn) {
+    notification.hidden = false;
+    // Trigger animation after a brief delay
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        notification.classList.add('show');
+      });
+    });
+
+    // Handle reload button click
+    const handleReload = () => {
+      // Clear stored version so after reload we pick up the new version
+      localStorage.removeItem(VERSION_STORAGE_KEY);
+      window.location.reload();
+    };
+
+    // Handle dismiss button click
+    const handleDismiss = () => {
+      notification.classList.remove('show');
+      setTimeout(() => {
+        notification.hidden = true;
+      }, 300);
+    };
+
+    // Remove existing listeners to prevent duplicates
+    reloadBtn.replaceWith(reloadBtn.cloneNode(true));
+    dismissBtn.replaceWith(dismissBtn.cloneNode(true));
+
+    // Re-query and add listeners
+    document.getElementById('update-reload-btn')?.addEventListener('click', handleReload);
+    document.getElementById('update-dismiss-btn')?.addEventListener('click', handleDismiss);
+  }
+}
+
+/**
+ * Checks for application updates by comparing version.json
+ */
+async function checkForUpdates(): Promise<void> {
+  console.log('Checking for application updates...');
+
+  const serverVersion = await fetchVersion();
+  if (!serverVersion) {
+    return; // Couldn't fetch version, try again later
+  }
+
+  // Skip update checks in development mode
+  if (serverVersion.version === 'development') {
+    console.log('Development mode - skipping version check');
+    return;
+  }
+
+  const storedVersion = localStorage.getItem(VERSION_STORAGE_KEY);
+
+  if (!storedVersion) {
+    // First visit or cleared storage - store current version
+    localStorage.setItem(VERSION_STORAGE_KEY, serverVersion.version);
+    console.log('Stored initial version:', serverVersion.version);
+    return;
+  }
+
+  if (storedVersion !== serverVersion.version) {
+    console.log(`New version available! Current: ${storedVersion}, New: ${serverVersion.version}`);
+    showUpdateNotification();
+  }
+}
+
 // Initialize the application
 async function init() {
   console.log('Co-do - AI File System Manager');
@@ -45,102 +151,33 @@ async function init() {
     }, 100);
   }
 
-  // Register Service Worker for PWA support
-  // Use import.meta.env.BASE_URL to dynamically determine the base path
+  // Register Service Worker for PWA support (caching only)
   if ('serviceWorker' in navigator) {
-    // Register immediately - no need to wait for 'load' event since we're already in init()
-    // which runs on or after DOMContentLoaded
     const swUrl = `${import.meta.env.BASE_URL}sw.js`;
-
-    // Track update check interval to prevent resource leaks
-    let updateCheckInterval: number | undefined;
 
     navigator.serviceWorker
       .register(swUrl)
       .then((registration) => {
         console.log('Service Worker registered successfully:', registration.scope);
-
-        // Function to check for updates
-        const checkForUpdates = () => {
-          console.log('Checking for service worker updates...');
-          registration.update().catch((err) => {
-            console.error('Service worker update check failed:', err);
-          });
-        };
-
-        // Check for updates periodically (every 60 seconds)
-        // Store interval ID to allow cleanup if needed
-        updateCheckInterval = window.setInterval(checkForUpdates, 60000);
-
-        // Also check for updates when the page becomes visible (user returns to tab)
-        document.addEventListener('visibilitychange', () => {
-          if (document.visibilityState === 'visible') {
-            checkForUpdates();
-          }
-        });
-
-        // Check immediately on load as well
-        checkForUpdates();
-
-        // Listen for controller changes and reload
-        // This is placed inside the registration promise to ensure it only runs after successful registration
-        navigator.serviceWorker.addEventListener('controllerchange', () => {
-          console.log('Service Worker controller changed, reloading...');
-          // Clean up interval before reload
-          if (updateCheckInterval !== undefined) {
-            clearInterval(updateCheckInterval);
-          }
-          window.location.reload();
-        });
-
-        // Listen for updates
-        registration.addEventListener('updatefound', () => {
-          const newWorker = registration.installing;
-          if (!newWorker) return;
-
-          newWorker.addEventListener('statechange', () => {
-            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              // New service worker is available, show update notification
-              console.log('New version available! Showing update notification...');
-
-              const notification = document.getElementById('update-notification');
-              const reloadBtn = document.getElementById('update-reload-btn');
-              const dismissBtn = document.getElementById('update-dismiss-btn');
-
-              if (notification && reloadBtn && dismissBtn) {
-                // Show the notification
-                notification.hidden = false;
-                // Trigger animation after a brief delay
-                requestAnimationFrame(() => {
-                  requestAnimationFrame(() => {
-                    notification.classList.add('show');
-                  });
-                });
-
-                // Handle reload button click
-                reloadBtn.addEventListener('click', () => {
-                  // Tell the new service worker to skip waiting
-                  // The controllerchange event will handle the reload
-                  newWorker.postMessage({ type: 'SKIP_WAITING' });
-                });
-
-                // Handle dismiss button click
-                dismissBtn.addEventListener('click', () => {
-                  notification.classList.remove('show');
-                  // Hide after animation completes
-                  setTimeout(() => {
-                    notification.hidden = true;
-                  }, 300);
-                });
-              }
-            }
-          });
-        });
       })
       .catch((error) => {
         console.error('Service Worker registration failed:', error);
       });
   }
+
+  // Set up version-based update checking
+  // Check for updates periodically
+  setInterval(checkForUpdates, VERSION_CHECK_INTERVAL);
+
+  // Check when page becomes visible (user returns to tab)
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      checkForUpdates();
+    }
+  });
+
+  // Check immediately on load
+  checkForUpdates();
 
   console.log('Application initialized successfully');
 }


### PR DESCRIPTION
Replace service worker-based update detection with a more reliable version.json approach. The Vite build now generates a version.json file containing a SHA-256 checksum of all built assets. The app periodically fetches this file and compares it with the stored version, showing an update notification when a new deployment is detected.

Changes:
- Add Vite plugin to generate version.json with project checksum
- Update main.ts to check version.json instead of service worker
- Simplify service worker to network-first caching strategy
- Ensure version.json is never cached by service worker