### PR TITLE
Move tool selection display above response

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1104,8 +1104,10 @@ export class UIManager {
     group.appendChild(content);
 
     // Insert after user message so tool selection is visible near the question
-    if (this.currentUserMessage && this.currentUserMessage.nextSibling) {
+    // insertBefore with null reference appends to the end
+    if (this.currentUserMessage) {
       this.elements.messages.insertBefore(group, this.currentUserMessage.nextSibling);
+      this.currentUserMessage = null; // Reset to avoid stale references in multi-turn conversations
     } else {
       this.elements.messages.appendChild(group);
     }


### PR DESCRIPTION
Previously, the tool activity group appeared after the assistant message started streaming, which meant it could get lost as the AI response grew.

Now the tool selection is inserted right after the user's question, making it more prominent and easier to see what tools are being used while the AI processes the request.