### PR TITLE
Fix contrast issues in file extension display

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -122,6 +122,7 @@ function getMarkdownStyles(): string {
       font-family: 'SF Mono', Monaco, 'Courier New', monospace;
       font-size: 0.875em;
       background: #F5F5F5;
+      color: #1A1A1A;
       padding: 0.2em 0.4em;
       border-radius: 4px;
     }


### PR DESCRIPTION
Add explicit color property to inline code elements in markdown rendering to ensure proper contrast when displayed. Without this, the text color could inherit unexpected values, causing readability issues where light text appeared on the light gray background.