### PR TITLE
Add close button to dismiss notification messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,10 @@
         </div>
 
         <div class="chat-input-wrapper">
-          <div id="status" class="status-bar"></div>
+          <div id="status" class="status-bar">
+            <span id="status-message" class="status-message"></span>
+            <button id="status-dismiss" class="status-dismiss" aria-label="Dismiss notification">&times;</button>
+          </div>
           <div class="chat-input-container">
             <textarea
               id="prompt-input"

--- a/src/styles.css
+++ b/src/styles.css
@@ -642,24 +642,53 @@ body {
   border-radius: var(--radius-md);
   font-size: 0.875rem;
   display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.status-message {
+  flex: 1;
+}
+
+.status-dismiss {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0 var(--spacing-xs);
+  opacity: 0.6;
+  color: inherit;
+  transition: opacity 0.2s ease;
+}
+
+.status-dismiss:hover {
+  opacity: 1;
+}
+
+.status-dismiss:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }
 
 .status-bar.info {
-  display: block;
+  display: flex;
   background: #E3F2FD;
   color: #1976D2;
   border: 1px solid #90CAF9;
 }
 
 .status-bar.success {
-  display: block;
+  display: flex;
   background: #E8F5E9;
   color: #388E3C;
   border: 1px solid #A5D6A7;
 }
 
 .status-bar.error {
-  display: block;
+  display: flex;
   background: #FFEBEE;
   color: #C62828;
   border: 1px solid #EF9A9A;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -27,6 +27,8 @@ export class UIManager {
     sendBtn: HTMLButtonElement;
     messages: HTMLDivElement;
     status: HTMLDivElement;
+    statusMessage: HTMLSpanElement;
+    statusDismiss: HTMLButtonElement;
     permissionSelects: NodeListOf<HTMLSelectElement>;
     infoBtn: HTMLButtonElement;
     settingsBtn: HTMLButtonElement;
@@ -89,6 +91,8 @@ export class UIManager {
       sendBtn: document.getElementById('send-btn') as HTMLButtonElement,
       messages: document.getElementById('messages') as HTMLDivElement,
       status: document.getElementById('status') as HTMLDivElement,
+      statusMessage: document.getElementById('status-message') as HTMLSpanElement,
+      statusDismiss: document.getElementById('status-dismiss') as HTMLButtonElement,
       permissionSelects: document.querySelectorAll('.permission-select'),
       infoBtn: document.getElementById('info-btn') as HTMLButtonElement,
       settingsBtn: document.getElementById('settings-btn') as HTMLButtonElement,
@@ -199,7 +203,7 @@ export class UIManager {
         // Auto-dismiss the status message after 10 seconds
         setTimeout(() => {
           // Only clear if the status is still showing the restore message
-          if (this.elements.status.textContent === 'Folder restored successfully') {
+          if (this.elements.statusMessage.textContent === 'Folder restored successfully') {
             this.setStatus('', 'info');
           }
         }, 10000);
@@ -228,6 +232,9 @@ export class UIManager {
         this.handleSendPrompt();
       }
     });
+
+    // Status bar dismiss button
+    this.elements.statusDismiss.addEventListener('click', () => this.dismissStatus());
 
     // Mobile menu toggle
     this.elements.mobileMenuBtn.addEventListener('click', () => this.toggleMobileSidebar());
@@ -730,7 +737,7 @@ export class UIManager {
       // Auto-dismiss the status message after 10 seconds
       setTimeout(() => {
         // Only clear if the status is still showing the folder loaded message
-        if (this.elements.status.textContent === 'Folder loaded successfully') {
+        if (this.elements.statusMessage.textContent === 'Folder loaded successfully') {
           this.setStatus('', 'info');
         }
       }, 10000);
@@ -1273,10 +1280,20 @@ export class UIManager {
   private setStatus(message: string, type: 'info' | 'success' | 'error'): void {
     // Use view transition for status updates
     withViewTransition(() => {
-      this.elements.status.textContent = message;
+      this.elements.statusMessage.textContent = message;
       // Only apply the type class if there's a message to display
       // This prevents showing an empty colored bar
       this.elements.status.className = message ? `status-bar ${type}` : 'status-bar';
+    });
+  }
+
+  /**
+   * Dismiss the status bar
+   */
+  private dismissStatus(): void {
+    withViewTransition(() => {
+      this.elements.statusMessage.textContent = '';
+      this.elements.status.className = 'status-bar';
     });
   }
 

--- a/tests/visual/ui-components.spec.ts
+++ b/tests/visual/ui-components.spec.ts
@@ -391,3 +391,96 @@ test.describe('Visual Regression - Update Notification', () => {
     await expect(dismissBtn).toHaveAttribute('aria-label', 'Dismiss');
   });
 });
+
+test.describe('Visual Regression - Status Bar', () => {
+  test('status bar is hidden by default', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    const statusBar = page.locator('#status');
+    await expect(statusBar).toBeHidden();
+  });
+
+  test('status bar displays correctly when shown', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Manually show the status bar for visual testing
+    await page.evaluate(() => {
+      const statusBar = document.getElementById('status');
+      const statusMessage = document.getElementById('status-message');
+      if (statusBar && statusMessage) {
+        statusMessage.textContent = 'Test status message';
+        statusBar.className = 'status-bar success';
+      }
+    });
+
+    const statusBar = page.locator('#status');
+    await expect(statusBar).toBeVisible();
+
+    await expect(statusBar).toHaveScreenshot('status-bar-success.png', {
+      animations: 'disabled',
+    });
+  });
+
+  test('status bar dismiss button is visible when status is shown', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Show the status bar
+    await page.evaluate(() => {
+      const statusBar = document.getElementById('status');
+      const statusMessage = document.getElementById('status-message');
+      if (statusBar && statusMessage) {
+        statusMessage.textContent = 'Test status message';
+        statusBar.className = 'status-bar info';
+      }
+    });
+
+    const dismissBtn = page.locator('#status-dismiss');
+    await expect(dismissBtn).toBeVisible();
+  });
+
+  test('clicking dismiss button hides the status bar', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Show the status bar
+    await page.evaluate(() => {
+      const statusBar = document.getElementById('status');
+      const statusMessage = document.getElementById('status-message');
+      if (statusBar && statusMessage) {
+        statusMessage.textContent = 'Test status message';
+        statusBar.className = 'status-bar success';
+      }
+    });
+
+    const statusBar = page.locator('#status');
+    await expect(statusBar).toBeVisible();
+
+    // Click the dismiss button
+    const dismissBtn = page.locator('#status-dismiss');
+    await dismissBtn.click();
+
+    // Wait for the status bar to be hidden
+    await expect(statusBar).toBeHidden();
+  });
+
+  test('status bar elements are properly structured', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // Verify all expected elements exist
+    const statusBar = page.locator('#status');
+    const statusMessage = page.locator('#status-message');
+    const dismissBtn = page.locator('#status-dismiss');
+
+    // Elements should exist in the DOM even if hidden
+    await expect(statusBar).toBeAttached();
+    await expect(statusMessage).toBeAttached();
+    await expect(dismissBtn).toBeAttached();
+
+    // Verify accessibility attributes
+    await expect(dismissBtn).toHaveAttribute('aria-label', 'Dismiss notification');
+  });
+});


### PR DESCRIPTION
Users can now click the X button to dismiss status bar messages (like "Response complete") instead of waiting for them to auto-clear.

Changes:
- Add dismiss button with X icon to status bar HTML
- Style dismiss button with hover/focus states and proper accessibility
- Update status bar to use flexbox layout for message + button
- Add dismissStatus method and click handler in UI manager