### PR TITLE
Fix asset loading for custom domain deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,14 +13,14 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'">
 
   <!-- PWA Configuration -->
-  <link rel="manifest" href="/Co-do/manifest.json">
+  <link rel="manifest" href="/manifest.json">
   <meta name="theme-color" content="#3b82f6">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Co-do">
-  <link rel="apple-touch-icon" href="/Co-do/icon-192.png">
-  <link rel="icon" type="image/png" sizes="192x192" href="/Co-do/icon-192.png">
-  <link rel="icon" type="image/png" sizes="512x512" href="/Co-do/icon-512.png">
+  <link rel="apple-touch-icon" href="/icon-192.png">
+  <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png">
 </head>
 <body>
   <div id="app">
@@ -35,7 +35,7 @@
           </svg>
         </button>
         <div class="app-branding">
-          <img src="/Co-do/icon.svg" alt="" class="app-icon" width="32" height="32">
+          <img src="/icon.svg" alt="" class="app-icon" width="32" height="32">
           <h1 class="app-title">Co-do</h1>
         </div>
         <div class="header-actions">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,7 +83,7 @@ function versionPlugin(): Plugin {
       // Serve a dev version.json during development
       // Use a fixed version in dev so the update notification doesn't appear
       server.middlewares.use((req, res, next) => {
-        if (req.url === '/Co-do/version.json') {
+        if (req.url === '/version.json') {
           const commitHash = getGitCommitHash();
           res.setHeader('Content-Type', 'application/json');
           res.end(
@@ -134,7 +134,7 @@ function versionPlugin(): Plugin {
 }
 
 export default defineConfig({
-  base: '/Co-do/',
+  base: '/',
   server: {
     port: 3000,
     headers: {


### PR DESCRIPTION
Changed base path from '/Co-do/' to '/' to support deployment on co-do.xyz custom domain. Assets were failing to load because they were looking for /Co-do/ prefix which is only needed for GitHub Pages deployment.

Changes:
- Updated vite.config.ts base path to '/' for root deployment
- Updated dev server middleware to serve version.json from root
- Updated index.html asset paths (manifest, icons, app icon) to use root paths

This fixes asset loading issues when deployed to co-do.xyz while maintaining proper functionality for local development.