### PR TITLE
Fix missing icon manifest resource error

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,27 +2,27 @@
   "name": "Co-do - AI File System Manager",
   "short_name": "Co-do",
   "description": "AI-powered file system manager using the File System Access API",
-  "start_url": "/Co-do/",
+  "start_url": "/",
   "display": "standalone",
   "background_color": "#0f172a",
   "theme_color": "#3b82f6",
   "orientation": "any",
-  "scope": "/Co-do/",
+  "scope": "/",
   "icons": [
     {
-      "src": "/Co-do/icon.svg",
+      "src": "/icon.svg",
       "sizes": "any",
       "type": "image/svg+xml",
       "purpose": "any"
     },
     {
-      "src": "/Co-do/icon-192.png",
+      "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/Co-do/icon-512.png",
+      "src": "/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
@@ -34,10 +34,10 @@
       "name": "Open Workspace",
       "short_name": "Workspace",
       "description": "Select a folder to work with",
-      "url": "/Co-do/?action=select-folder",
+      "url": "/?action=select-folder",
       "icons": [
         {
-          "src": "/Co-do/icon-192.png",
+          "src": "/icon-192.png",
           "sizes": "192x192"
         }
       ]


### PR DESCRIPTION
The manifest.json had hardcoded /Co-do/ prefixes for icon paths, start_url, and scope, which caused 404 errors when the site is deployed to the root of a custom domain (co-do.xyz).

Changed all paths to use root-relative URLs (e.g., /icon.svg instead of /Co-do/icon.svg) to match index.html and vite.config.ts which both use base: '/'.