### PR TITLE
Position tool activity header between request and response

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1212,8 +1212,8 @@ export class UIManager {
       this.updateTabTitle(conversationId, prompt);
     }
 
-    // Add user message to UI
-    this.addMessage('user', prompt);
+    // Add user message to UI and track it for tool activity positioning
+    this.currentUserMessage = this.addMessage('user', prompt);
     this.elements.promptInput.value = '';
 
     // Save user message to storage and memory


### PR DESCRIPTION
The tool activity group was being appended to the end of messages instead of being inserted after the user message. This was because currentUserMessage was declared but never assigned when a user message was added.

Now the user message element is tracked so the tool activity group can be properly inserted after it but before the AI response.