### PR TITLE
Add padding to system response messages

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -537,8 +537,7 @@ body {
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-sm);
   width: 100%;
-  max-width: none;
-  margin-right: var(--spacing-xl);
+  max-width: calc(100% - var(--spacing-xl));
 }
 
 /* Markdown content wrapper - constrains height with expand capability */
@@ -1516,8 +1515,7 @@ dialog.permission-dialog[open] {
 
   .message.assistant {
     width: 100%;
-    max-width: none;
-    margin-right: var(--spacing-lg);
+    max-width: calc(100% - var(--spacing-lg));
   }
 
   /* Ensure status bar uses default positioning to prevent conflicts with fixed input wrapper */


### PR DESCRIPTION
Assistant messages now have additional right-side margin to visually distinguish them from user messages which align to the right edge. Uses --spacing-xl (2rem) on desktop and --spacing-lg (1.5rem) on mobile.