### PR TITLE
Fix double flash when clearing messages

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2457,10 +2457,6 @@ dialog.permission-dialog[open] {
   view-transition-name: folder-info;
 }
 
-.status-bar {
-  view-transition-name: status-bar;
-}
-
 .chat-input-wrapper {
   view-transition-name: chat-input-wrapper;
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1823,23 +1823,18 @@ export class UIManager {
    * Set status message
    */
   private setStatus(message: string, type: 'info' | 'success' | 'error'): void {
-    // Use view transition for status updates
-    withViewTransition(() => {
-      this.elements.statusMessage.textContent = message;
-      // Only apply the type class if there's a message to display
-      // This prevents showing an empty colored bar
-      this.elements.status.className = message ? `status-bar ${type}` : 'status-bar';
-    });
+    this.elements.statusMessage.textContent = message;
+    // Only apply the type class if there's a message to display
+    // This prevents showing an empty colored bar
+    this.elements.status.className = message ? `status-bar ${type}` : 'status-bar';
   }
 
   /**
    * Dismiss the status bar
    */
   private dismissStatus(): void {
-    withViewTransition(() => {
-      this.elements.statusMessage.textContent = '';
-      this.elements.status.className = 'status-bar';
-    });
+    this.elements.statusMessage.textContent = '';
+    this.elements.status.className = 'status-bar';
   }
 
   /**


### PR DESCRIPTION
Remove unnecessary View Transitions API usage from status bar updates. The view transition wrapper and CSS view-transition-name were causing a visual "double flash" effect when dismissing status messages.

- Remove withViewTransition() wrapper from setStatus() and dismissStatus()
- Remove view-transition-name: status-bar from CSS

Status bar show/hide is now instantaneous, eliminating the flickering.