### PR TITLE
Fix microphone recorder positioning in text area

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1017,11 +1017,11 @@ body {
 @keyframes pulse-recording {
   0%, 100% {
     opacity: 1;
-    transform: scale(1);
+    transform: translateY(-50%) scale(1);
   }
   50% {
     opacity: 0.85;
-    transform: scale(1.08);
+    transform: translateY(-50%) scale(1.08);
   }
 }
 


### PR DESCRIPTION
The pulse-recording animation was overriding the translateY(-50%) transform that centers the button vertically, causing it to drop down outside the text area during recording. Added translateY(-50%) to the animation keyframes to maintain vertical centering.