### PR TITLE
feat: Include WASM build in deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup WASI SDK
+        run: |
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/wasi-sdk-24.0-x86_64-linux.tar.gz
+          tar xzf wasi-sdk-24.0-x86_64-linux.tar.gz
+          sudo mv wasi-sdk-24.0-x86_64-linux /opt/wasi-sdk
+          echo "WASI_SDK_PATH=/opt/wasi-sdk" >> $GITHUB_ENV
+
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "npm run wasm:build && tsc && vite build && mkdir -p dist/wasm-tools/binaries && (cp wasm-tools/binaries/*.wasm dist/wasm-tools/binaries/ 2>/dev/null || echo 'No WASM binaries to copy')",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
     "test": "playwright test",
@@ -20,6 +20,7 @@
     "test:headed": "playwright test --headed",
     "test:debug": "playwright test --debug",
     "test:report": "playwright show-report",
+    "build:web-only": "tsc && vite build",
     "wasm:build": "bash wasm-tools/build.sh",
     "wasm:build:native": "bash wasm-tools/build.sh --native-only",
     "wasm:help": "bash wasm-tools/build.sh --help"


### PR DESCRIPTION
## Summary
- Update build script to run `wasm:build` and copy WASM binaries to `dist/wasm-tools/binaries/`
- Add WASI SDK setup step to deploy.yml workflow for CI/CD
- Add `build:web-only` script for development without WASI SDK installed

## Test plan
- [ ] Verify `npm run build` runs WASM build and copies binaries to dist
- [ ] Verify GitHub Actions deploy workflow installs WASI SDK and builds successfully
- [ ] Verify WASM tools are available in deployed site at `wasm-tools/binaries/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)