### PR TITLE
fix: Remove ZSTD library due to build failures

### DIFF
--- a/docs/WASM-TOOLS-PLAN.md
+++ b/docs/WASM-TOOLS-PLAN.md
@@ -791,7 +791,6 @@ await aiManager.streamCompletion(prompt, messages, allTools, ...);
 | gzip | compression | Compress data using gzip |
 | gunzip | compression | Decompress gzip data |
 | brotli | compression | Compress using Brotli algorithm |
-| zstd | compression | Compress using Zstandard |
 | csvtool | data | CSV manipulation utilities |
 | toml2json | data | Convert TOML to JSON |
 | markdown | data | Convert Markdown to HTML |

--- a/src/wasm-tools/registry.ts
+++ b/src/wasm-tools/registry.ts
@@ -986,7 +986,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
   },
 
   // ==========================================================================
-  // Compression Tools (3 tools)
+  // Compression Tools (2 tools)
   // ==========================================================================
   {
     name: 'gzip',
@@ -1039,33 +1039,6 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
       { category: 'compression', argStyle: 'cli', timeout: 60000 }
     ),
   },
-  {
-    name: 'zstd',
-    category: 'compression',
-    wasmUrl: 'wasm-tools/binaries/zstd.wasm',
-    manifest: createManifest(
-      'zstd',
-      'Compress or decompress data using Zstandard format. Reads from stdin, writes to stdout.',
-      {
-        type: 'object',
-        properties: {
-          decompress: {
-            type: 'boolean',
-            description: 'Decompress instead of compress (-d)',
-            default: false,
-          },
-          level: {
-            type: 'number',
-            description: 'Compression level 1-19 (default: 3)',
-            default: 3,
-          },
-        },
-        required: [],
-      },
-      { category: 'compression', argStyle: 'cli', timeout: 60000 }
-    ),
-  },
-
   // ==========================================================================
   // Database Tools (1 tool)
   // ==========================================================================

--- a/wasm-tools/LIBRARIES.md
+++ b/wasm-tools/LIBRARIES.md
@@ -16,7 +16,6 @@ These tools should be built from their official source code using WASI SDK:
 |------|---------|--------|-------------|
 | gzip/gunzip | zlib | https://github.com/nicknisi/zlib-wasm | Compile with WASI SDK |
 | brotli | brotli | https://github.com/nicknisi/brotli-wasm | Official library |
-| zstd | zstd | https://github.com/nicknisi/zstd-wasm | Official library |
 | xz | liblzma | https://tukaani.org/xz/ | Part of XZ Utils |
 
 ### Archive


### PR DESCRIPTION
## Summary
- Remove ZSTD compression tool from the WASM tools registry
- Remove ZSTD build function from the build script
- Update documentation to reflect the removal

## Test plan
- [x] TypeScript compiles successfully (`npm run type-check`)
- [x] Build succeeds (`npm run build`)
- [x] No remaining ZSTD library references (only magic bytes detection for file type identification remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)