### PR TITLE
Make markdown renderer background transparent

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -21,11 +21,16 @@ function getMarkdownStyles(): string {
       box-sizing: border-box;
     }
 
+    html {
+      background: transparent;
+    }
+
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       font-size: 15px;
       line-height: 1.6;
       color: #1A1A1A;
+      background: transparent;
       padding: 0;
       overflow-wrap: break-word;
       word-wrap: break-word;


### PR DESCRIPTION
## Summary
Updated the markdown renderer styles to use transparent backgrounds for both the `html` and `body` elements, allowing the parent container's styling to show through.

## Changes
- Added `background: transparent;` to the `html` element styles
- Added `background: transparent;` to the `body` element styles

## Details
These changes ensure that the markdown renderer doesn't impose a default background color, making it more flexible for integration into different UI contexts. This allows the markdown content to inherit or display against whatever background is set by the parent container.

https://claude.ai/code/session_01YS1FUwJ1SQsPAF8EaffXgh