### PR TITLE
Add dark/light color-scheme support to markdown renderer

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -23,6 +23,7 @@ function getMarkdownStyles(): string {
 
     html {
       background: transparent;
+      color-scheme: dark light;
     }
 
     body {
@@ -265,6 +266,7 @@ function createIframeDocument(markdownContent: string): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark light">
   <style>${getMarkdownStyles()}</style>
 </head>
 <body>${html}</body>


### PR DESCRIPTION
## Summary
This PR adds support for both dark and light color schemes in the markdown renderer by declaring color-scheme preferences in both CSS and HTML meta tags.

## Changes
- Added `color-scheme: dark light;` CSS property to the `html` element in markdown styles
- Added `<meta name="color-scheme" content="dark light">` meta tag to the iframe document head

## Details
These changes enable the browser and operating system to automatically apply appropriate color schemes based on user preferences. The declaration in both the CSS and meta tag ensures consistent behavior across different rendering contexts. This allows the markdown content to respect system-level dark/light mode settings without requiring explicit theme switching logic.

https://claude.ai/code/session_01ErTHKQRaWVMbYxoNp859wd