### PR TITLE
Refactor version checking to use SharedWorker for cross-tab deduplication

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -120,7 +120,11 @@ function setupVersionChecking(): void {
     }
   };
 
-  let sendMessage: (msg: { type: string; baseUrl?: string }) => void;
+  type ClientMessage =
+    | { type: 'init'; baseUrl: string }
+    | { type: 'check-now' };
+
+  let sendMessage: (msg: ClientMessage) => void;
 
   // Vite requires `new URL(...)` to be inlined directly in the Worker/SharedWorker
   // constructor for static analysis to recognise it as a worker entry point.


### PR DESCRIPTION
## Summary
Moves version checking logic from the main thread into a dedicated worker that uses SharedWorker (with Worker fallback) to deduplicate polling across browser tabs. This reduces unnecessary network requests when multiple tabs are open and offloads polling from the main thread.

## Key Changes
- **Extracted version checking to worker**: Created new `version-check-worker.ts` that handles all version polling logic
- **SharedWorker with fallback**: Implements SharedWorker for cross-tab deduplication (single network request per interval regardless of tab count), with automatic fallback to regular Worker for platforms without SharedWorker support (e.g., Android WebView)
- **Refactored main thread**: Removed `fetchVersion()` and `checkForUpdates()` from `main.ts`, replaced with `setupVersionChecking()` that initializes the worker and handles incoming version info
- **Improved visibility handling**: Version checks now trigger immediately when a tab becomes visible via `visibilitychange` event
- **Removed polling interval constant**: Moved `VERSION_CHECK_INTERVAL` to the worker where it's actually used

## Implementation Details
- The worker detects whether it's running as a SharedWorker or DedicatedWorker and adapts its port management accordingly
- SharedWorker maintains a single polling loop shared across all tabs; DedicatedWorker runs one per tab
- Tabs communicate with the worker via a simple message protocol: `init` (start polling), `check-now` (immediate check), and `version-info` (version data broadcast)
- The worker caches the latest version info and sends it immediately to newly connected tabs, avoiding unnecessary waits for the next poll cycle
- Development mode filtering is now handled in the worker to avoid unnecessary broadcasts

https://claude.ai/code/session_01UWzTgBYvtW4zhyEZs5mVpG