### PR TITLE
Add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-sonnet-4-5-20250929"


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that integrates Claude AI into the repository, enabling automated code assistance through mentions of `@claude` in issues, pull requests, and comments.

## Changes
- Added `.github/workflows/claude.yml` workflow file that:
  - Triggers on issue comments, pull request review comments, pull request reviews, and issue creation/assignment events
  - Filters events to only run when `@claude` is mentioned in the relevant content
  - Uses the official `anthropics/claude-code-action@v1` action
  - Configures Claude Sonnet 4.5 as the AI model for code assistance
  - Sets appropriate permissions for reading repository content and pull request/issue data

## Implementation Details
- The workflow uses conditional logic to detect `@claude` mentions across multiple event types (comments, reviews, and issues)
- Minimal permissions are granted following the principle of least privilege (read-only access to contents, PRs, and issues)
- Uses a pinned version of the checkout action for reproducibility
- Requires `ANTHROPIC_API_KEY` secret to be configured in the repository settings

https://claude.ai/code/session_01RnN557j5ZCrL2agtZuoo1c