### PR TITLE
Add stdin support to WASM tools and improve output display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "co-do",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "co-do",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.15",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2217,41 +2217,33 @@ export class UIManager {
       const hasResultId = resultObj && typeof resultObj === 'object' && 'resultId' in resultObj;
 
       if (hasResultId) {
-        // Result has cached content - show summary and full content button
+        // Result has cached content - show summary and full output
         const resultId = resultObj.resultId as string;
         const cachedResult = toolResultCache.get(resultId);
 
-        // Create summary display
-        const summaryInfo = this.formatToolResultSummary(resultObj);
-
+        // Create result container (auto-expanded so WASM output is visible)
         const resultDetails = document.createElement('details');
         resultDetails.className = 'tool-item-details tool-result-details';
+        resultDetails.open = true;
 
         const summaryEl = document.createElement('summary');
-        summaryEl.textContent = 'Result';
+        const lineInfo = cachedResult?.metadata.lineCount ?? (resultObj.lineCount as number | undefined);
+        summaryEl.textContent = `Output${lineInfo ? ` (${lineInfo} lines)` : ''}`;
         resultDetails.appendChild(summaryEl);
 
-        // Add summary info
-        const summaryPre = document.createElement('pre');
-        summaryPre.className = 'tool-item-result tool-result-summary';
-        summaryPre.textContent = summaryInfo;
-        resultDetails.appendChild(summaryPre);
-
-        // Add full content section if cached
+        // Show full content directly if cached
         if (cachedResult) {
-          const fullContentDetails = document.createElement('details');
-          fullContentDetails.className = 'tool-full-content-details';
-
-          const fullContentSummary = document.createElement('summary');
-          fullContentSummary.textContent = `View Full Content (${cachedResult.metadata.lineCount ?? '?'} lines)`;
-          fullContentDetails.appendChild(fullContentSummary);
-
           const fullContentPre = document.createElement('pre');
           fullContentPre.className = 'tool-item-result tool-full-content';
           fullContentPre.textContent = cachedResult.fullContent;
-          fullContentDetails.appendChild(fullContentPre);
-
-          resultDetails.appendChild(fullContentDetails);
+          resultDetails.appendChild(fullContentPre);
+        } else {
+          // Fallback: show the summary info if cache expired
+          const summaryInfo = this.formatToolResultSummary(resultObj);
+          const summaryPre = document.createElement('pre');
+          summaryPre.className = 'tool-item-result tool-result-summary';
+          summaryPre.textContent = summaryInfo;
+          resultDetails.appendChild(summaryPre);
         }
 
         toolItem.appendChild(resultDetails);

--- a/src/wasm-tools/registry.ts
+++ b/src/wasm-tools/registry.ts
@@ -21,6 +21,7 @@ function createManifest(
     fileAccess?: 'none' | 'read' | 'write' | 'readwrite';
     timeout?: number;
     pipeable?: boolean;
+    stdinParam?: string;
   }
 ): WasmToolManifest {
   return {
@@ -36,6 +37,7 @@ function createManifest(
       argStyle: options.argStyle ?? 'positional',
       fileAccess: options.fileAccess ?? 'none',
       timeout: options.timeout ?? 30000,
+      stdinParam: options.stdinParam,
     },
     pipeable: options.pipeable,
     category: options.category,
@@ -74,7 +76,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['mode', 'input'],
       },
-      { category: 'crypto', argStyle: 'positional', pipeable: true }
+      { category: 'crypto', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -94,7 +96,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'crypto', argStyle: 'positional', pipeable: true }
+      { category: 'crypto', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -114,7 +116,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'crypto', argStyle: 'positional', pipeable: true }
+      { category: 'crypto', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -134,7 +136,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'crypto', argStyle: 'positional', pipeable: true }
+      { category: 'crypto', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -143,7 +145,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
     wasmUrl: 'wasm-tools/binaries/xxd.wasm',
     manifest: createManifest(
       'xxd',
-      'Create a hex dump of text or reverse a hex dump back to text.',
+      'Create a hex dump of text or reverse a hex dump back to text. The input text is sent via stdin.',
       {
         type: 'object',
         properties: {
@@ -159,7 +161,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['mode', 'input'],
       },
-      { category: 'crypto', argStyle: 'positional', pipeable: true }
+      { category: 'crypto', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -219,7 +221,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -244,7 +246,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -269,7 +271,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -298,7 +300,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input', 'fields'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -333,7 +335,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -368,7 +370,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -396,7 +398,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input', 'set1'],
       },
-      { category: 'text', argStyle: 'positional', pipeable: true }
+      { category: 'text', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -440,7 +442,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['pattern', 'input'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -464,7 +466,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['expression', 'input'],
       },
-      { category: 'text', argStyle: 'positional', pipeable: true }
+      { category: 'text', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -492,7 +494,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['program', 'input'],
       },
-      { category: 'text', argStyle: 'cli', pipeable: true }
+      { category: 'text', argStyle: 'cli', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -569,7 +571,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'data', argStyle: 'positional', pipeable: true }
+      { category: 'data', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -602,7 +604,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['command', 'input'],
       },
-      { category: 'data', argStyle: 'positional', pipeable: true }
+      { category: 'data', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -622,7 +624,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'data', argStyle: 'positional', pipeable: true }
+      { category: 'data', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -642,7 +644,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['token'],
       },
-      { category: 'data', argStyle: 'positional', pipeable: true }
+      { category: 'data', argStyle: 'positional', pipeable: true, stdinParam: 'token' }
     ),
   },
   {
@@ -667,7 +669,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'data', argStyle: 'positional', pipeable: true }
+      { category: 'data', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -691,7 +693,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['expression', 'input'],
       },
-      { category: 'data', argStyle: 'positional', pipeable: true }
+      { category: 'data', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
 
@@ -866,7 +868,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'code', argStyle: 'positional', pipeable: true }
+      { category: 'code', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -886,7 +888,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'code', argStyle: 'positional', pipeable: true }
+      { category: 'code', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -906,7 +908,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'code', argStyle: 'positional', pipeable: true }
+      { category: 'code', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -926,7 +928,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'code', argStyle: 'positional', pipeable: true }
+      { category: 'code', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
   {
@@ -946,7 +948,7 @@ export const BUILTIN_TOOLS: BuiltinToolConfig[] = [
         },
         required: ['input'],
       },
-      { category: 'code', argStyle: 'positional', pipeable: true }
+      { category: 'code', argStyle: 'positional', pipeable: true, stdinParam: 'input' }
     ),
   },
 

--- a/src/wasm-tools/types.ts
+++ b/src/wasm-tools/types.ts
@@ -45,6 +45,7 @@ export const WasmToolManifestSchema = z.object({
     fileAccess: z.enum(['none', 'read', 'write', 'readwrite']),
     memoryLimit: z.number().optional(),
     timeout: z.number().optional(),
+    stdinParam: z.string().optional(),
   }),
   pipeable: z.boolean().optional(),
   category: z.string(),
@@ -97,6 +98,8 @@ export interface WasmToolManifest {
     fileAccess: 'none' | 'read' | 'write' | 'readwrite';
     memoryLimit?: number;
     timeout?: number;
+    /** Parameter name whose value should be sent via stdin instead of argv */
+    stdinParam?: string;
   };
 
   // Pipe support

--- a/wasm-tools/src/awk/main.c
+++ b/wasm-tools/src/awk/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 #define MAX_FIELDS 1024
 #define MAX_LINE 65536
@@ -266,7 +267,7 @@ void run_program(const char *program, const char *text) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 3) {
+    if (argc < 2) {
         fprintf(stderr, "Usage: awk [-F sep] <program> <text>\n");
         fprintf(stderr, "Examples:\n");
         fprintf(stderr, "  awk '{print $1}' \"hello world\"\n");
@@ -287,15 +288,28 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (argc - arg_idx < 2) {
-        fprintf(stderr, "Error: Missing program or text\n");
+    if (argc - arg_idx < 1) {
+        fprintf(stderr, "Error: Missing program\n");
         return 1;
     }
 
     const char *program = argv[arg_idx];
-    const char *text = argv[arg_idx + 1];
+    const char *text = NULL;
+    char *stdin_buf = NULL;
+
+    if (argc - arg_idx >= 2) {
+        text = argv[arg_idx + 1];
+    } else {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Error: Missing text (provide as argument or via stdin)\n");
+            return 1;
+        }
+        text = stdin_buf;
+    }
 
     run_program(program, text);
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/base64/main.c
+++ b/wasm-tools/src/base64/main.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 static const char b64_table[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -71,20 +72,32 @@ void decode(const char *input) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: base64 <encode|decode> <input>\n");
+    if (argc < 2) {
+        fprintf(stderr, "Usage: base64 <encode|decode> [input]\n");
         return 1;
+    }
+
+    const char *input = (argc >= 3) ? argv[2] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: base64 <encode|decode> <input>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
     if (strcmp(argv[1], "encode") == 0) {
-        encode(argv[2]);
+        encode(input);
     } else if (strcmp(argv[1], "decode") == 0) {
-        decode(argv[2]);
+        decode(input);
     } else {
         fprintf(stderr, "Unknown mode: %s\n", argv[1]);
-        fprintf(stderr, "Usage: base64 <encode|decode> <input>\n");
+        free(stdin_buf);
         return 1;
     }
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/csso/main.c
+++ b/wasm-tools/src/csso/main.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 void optimize_css(const char *css) {
     int in_comment = 0;
@@ -118,13 +119,20 @@ void optimize_css(const char *css) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: csso <css-code>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: csso <css-code>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
-    optimize_css(argv[1]);
+    optimize_css(input);
     printf("\n");
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/cut/main.c
+++ b/wasm-tools/src/cut/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 int main(int argc, char **argv) {
     char delimiter = '\t';  // Default delimiter
@@ -22,8 +23,19 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (!input || field < 1) {
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: cut -d DELIMITER -f FIELD <text>\n");
+            return 1;
+        }
+        input = stdin_buf;
+    }
+
+    if (field < 1) {
         fprintf(stderr, "Usage: cut -d DELIMITER -f FIELD <text>\n");
+        free(stdin_buf);
         return 1;
     }
 
@@ -60,5 +72,6 @@ int main(int argc, char **argv) {
         line_start = *line_end ? line_end + 1 : line_end;
     }
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/grep/main.c
+++ b/wasm-tools/src/grep/main.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include "../stdin_read.h"
 
 // Case-insensitive strstr
 char *strcasestr_impl(const char *haystack, const char *needle) {
@@ -51,9 +52,15 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (!pattern || !input) {
-        fprintf(stderr, "Usage: grep [-i] [-v] [-n] [-c] PATTERN <text>\n");
+    char *stdin_buf = NULL;
+    if (!pattern) {
+        fprintf(stderr, "Usage: grep [-i] [-v] [-n] [-c] PATTERN <text>\nOr pipe text via stdin.\n");
         return 1;
+    }
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) { fprintf(stderr, "Usage: grep [-i] [-v] [-n] [-c] PATTERN <text>\nOr pipe text via stdin.\n"); return 1; }
+        input = stdin_buf;
     }
 
     char *input_copy = strdup(input);
@@ -92,5 +99,6 @@ int main(int argc, char **argv) {
     }
 
     free(input_copy);
+    free(stdin_buf);
     return match_count > 0 ? 0 : 1;
 }

--- a/wasm-tools/src/head/main.c
+++ b/wasm-tools/src/head/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 int main(int argc, char **argv) {
     int num_lines = 10;  // Default
@@ -19,9 +20,11 @@ int main(int argc, char **argv) {
         }
     }
 
+    char *stdin_buf = NULL;
     if (!input) {
-        fprintf(stderr, "Usage: head [-n NUM] <text>\n");
-        return 1;
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) { fprintf(stderr, "Usage: head [-n NUM] <text>\nOr pipe input via stdin.\n"); return 1; }
+        input = stdin_buf;
     }
 
     int lines = 0;
@@ -35,5 +38,6 @@ int main(int argc, char **argv) {
         putchar('\n');
     }
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/html-minifier/main.c
+++ b/wasm-tools/src/html-minifier/main.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 void minify_html(const char *html) {
     int in_tag = 0;
@@ -106,13 +107,20 @@ void minify_html(const char *html) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: html-minifier <html-code>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: html-minifier <html-code>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
-    minify_html(argv[1]);
+    minify_html(input);
     printf("\n");
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/jwt/main.c
+++ b/wasm-tools/src/jwt/main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 // Base64URL alphabet
 static const char b64url_table[] =
@@ -118,8 +119,8 @@ void encode_jwt(const char *payload) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: jwt <encode|decode> <payload|token>\n");
+    if (argc < 2) {
+        fprintf(stderr, "Usage: jwt <encode|decode> [payload|token]\n");
         fprintf(stderr, "\nCommands:\n");
         fprintf(stderr, "  decode <token>    Decode and display JWT parts\n");
         fprintf(stderr, "  encode <payload>  Create unsigned JWT from JSON payload\n");
@@ -128,7 +129,13 @@ int main(int argc, char **argv) {
     }
 
     const char *cmd = argv[1];
-    const char *data = argv[2];
+    const char *data = (argc >= 3) ? argv[2] : NULL;
+    char *stdin_buf = NULL;
+    if (!data) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) { fprintf(stderr, "Usage: jwt <encode|decode> <payload|token>\nOr pipe input via stdin.\n"); return 1; }
+        data = stdin_buf;
+    }
 
     if (strcmp(cmd, "decode") == 0) {
         decode_jwt(data);
@@ -136,8 +143,10 @@ int main(int argc, char **argv) {
         encode_jwt(data);
     } else {
         fprintf(stderr, "Error: Unknown command '%s'\n", cmd);
+        free(stdin_buf);
         return 1;
     }
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/markdown/main.c
+++ b/wasm-tools/src/markdown/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 // HTML escape
 void print_escaped(const char *text) {
@@ -226,12 +227,18 @@ void process_line(const char *line, int *in_code_block, int *in_list) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: markdown <markdown-text>\n");
-        return 1;
+    const char *raw_input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!raw_input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: markdown <markdown-text>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        raw_input = stdin_buf;
     }
 
-    char *input = strdup(argv[1]);
+    char *input = strdup(raw_input);
     char *line = strtok(input, "\n");
     int in_code_block = 0;
     int in_list = 0;
@@ -250,5 +257,6 @@ int main(int argc, char **argv) {
     }
 
     free(input);
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/md5sum/main.c
+++ b/wasm-tools/src/md5sum/main.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "../stdin_read.h"
 
 #define LEFTROTATE(x, c) (((x) << (c)) | ((x) >> (32 - (c))))
 
@@ -80,18 +81,25 @@ void md5(const uint8_t *data, size_t len, uint8_t *hash) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: md5sum <text>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: md5sum <text>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
     uint8_t hash[16];
-    md5((const uint8_t *)argv[1], strlen(argv[1]), hash);
+    md5((const uint8_t *)input, strlen(input), hash);
 
     for (int i = 0; i < 16; i++) {
         printf("%02x", hash[i]);
     }
     printf("\n");
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/minify/main.c
+++ b/wasm-tools/src/minify/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 // Minify CSS
 void minify_css(const char *css) {
@@ -275,14 +276,22 @@ void minify_html(const char *html) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: minify <type> <code>\n");
-        fprintf(stderr, "Types: html, css, js\n");
+    if (argc < 2) {
+        fprintf(stderr, "Usage: minify <type> <code>\nTypes: html, css, js\nOr pipe code via stdin.\n");
         return 1;
     }
 
     const char *type = argv[1];
-    const char *code = argv[2];
+    const char *code = (argc >= 3) ? argv[2] : NULL;
+    char *stdin_buf = NULL;
+    if (!code) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: minify <type> <code>\nOr pipe code via stdin.\n");
+            return 1;
+        }
+        code = stdin_buf;
+    }
 
     if (strcmp(type, "css") == 0) {
         minify_css(code);
@@ -296,5 +305,6 @@ int main(int argc, char **argv) {
     }
 
     printf("\n");
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/sed/main.c
+++ b/wasm-tools/src/sed/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 #define MAX_LINE 65536
 
@@ -156,15 +157,19 @@ int parse_substitute(const char *expr, char *pattern, char *replacement, int *gl
 }
 
 int main(int argc, char **argv) {
-    if (argc < 3) {
-        fprintf(stderr, "Usage: sed <expression> <text>\n");
-        fprintf(stderr, "Expressions:\n");
-        fprintf(stderr, "  s/pattern/replacement/[g]  Substitute\n");
+    if (argc < 2) {
+        fprintf(stderr, "Usage: sed <expression> [text]\nOr pipe text via stdin.\n");
         return 1;
     }
 
     const char *expr = argv[1];
-    const char *text = argv[2];
+    const char *text = (argc >= 3) ? argv[2] : NULL;
+    char *stdin_buf = NULL;
+    if (!text) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) { fprintf(stderr, "Usage: sed <expression> <text>\nOr pipe text via stdin.\n"); return 1; }
+        text = stdin_buf;
+    }
 
     char pattern[1024];
     char replacement[1024];
@@ -186,5 +191,6 @@ int main(int argc, char **argv) {
         return 1;
     }
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/sha256sum/main.c
+++ b/wasm-tools/src/sha256sum/main.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
+#include "../stdin_read.h"
 
 // SHA-256 constants
 static const uint32_t K[64] = {
@@ -91,12 +92,17 @@ void sha256(const uint8_t *data, size_t len, uint8_t *hash) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: sha256sum <text>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: sha256sum <text>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
-    const char *input = argv[1];
     uint8_t hash[32];
 
     sha256((const uint8_t *)input, strlen(input), hash);
@@ -106,5 +112,6 @@ int main(int argc, char **argv) {
     }
     printf("\n");
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/sha512sum/main.c
+++ b/wasm-tools/src/sha512sum/main.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "../stdin_read.h"
 
 static const uint64_t K[80] = {
     0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL, 0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
@@ -92,18 +93,25 @@ void sha512(const uint8_t *data, size_t len, uint8_t *hash) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: sha512sum <text>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: sha512sum <text>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
     uint8_t hash[64];
-    sha512((const uint8_t *)argv[1], strlen(argv[1]), hash);
+    sha512((const uint8_t *)input, strlen(input), hash);
 
     for (int i = 0; i < 64; i++) {
         printf("%02x", hash[i]);
     }
     printf("\n");
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/shfmt/main.c
+++ b/wasm-tools/src/shfmt/main.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 #define MAX_LINE 4096
 
@@ -125,12 +126,19 @@ void format_shell(const char *script) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: shfmt <shell-script>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: shfmt <shell-script>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
-    format_shell(argv[1]);
+    format_shell(input);
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/sort/main.c
+++ b/wasm-tools/src/sort/main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 #define MAX_LINES 10000
 #define MAX_LINE_LEN 4096
@@ -43,9 +44,11 @@ int main(int argc, char **argv) {
         }
     }
 
+    char *stdin_buf = NULL;
     if (!input) {
-        fprintf(stderr, "Usage: sort [-r] [-n] <text>\n");
-        return 1;
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) { fprintf(stderr, "Usage: sort [-r] [-n] <text>\nOr pipe input via stdin.\n"); return 1; }
+        input = stdin_buf;
     }
 
     // Split input into lines
@@ -66,5 +69,6 @@ int main(int argc, char **argv) {
     }
 
     free(input_copy);
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/stdin_read.h
+++ b/wasm-tools/src/stdin_read.h
@@ -1,0 +1,49 @@
+/**
+ * Common stdin reading utility for WASM tools.
+ *
+ * Provides read_all_stdin() which reads all of stdin into a
+ * dynamically allocated null-terminated buffer. Returns NULL
+ * if stdin is empty or allocation fails.
+ *
+ * Usage in a tool's main():
+ *   if (!input) {
+ *       input = read_all_stdin();
+ *       if (!input) { fprintf(stderr, "Usage: ..."); return 1; }
+ *       stdin_used = 1;
+ *   }
+ *   // ... process input ...
+ *   if (stdin_used) free((void *)input);
+ */
+
+#ifndef STDIN_READ_H
+#define STDIN_READ_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static char *read_all_stdin(void) {
+    size_t cap = 4096, len = 0;
+    char *buf = (char *)malloc(cap);
+    if (!buf) return NULL;
+
+    while (1) {
+        size_t n = fread(buf + len, 1, cap - len, stdin);
+        len += n;
+        if (n < cap - len) break; /* EOF or error */
+        cap *= 2;
+        char *tmp = (char *)realloc(buf, cap);
+        if (!tmp) { free(buf); return NULL; }
+        buf = tmp;
+    }
+
+    if (len == 0) { free(buf); return NULL; }
+
+    /* Null-terminate */
+    char *tmp = (char *)realloc(buf, len + 1);
+    if (tmp) buf = tmp;
+    buf[len] = '\0';
+
+    return buf;
+}
+
+#endif /* STDIN_READ_H */

--- a/wasm-tools/src/tail/main.c
+++ b/wasm-tools/src/tail/main.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 int main(int argc, char **argv) {
     int num_lines = 10;  // Default
@@ -19,9 +20,11 @@ int main(int argc, char **argv) {
         }
     }
 
+    char *stdin_buf = NULL;
     if (!input) {
-        fprintf(stderr, "Usage: tail [-n NUM] <text>\n");
-        return 1;
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) { fprintf(stderr, "Usage: tail [-n NUM] <text>\nOr pipe input via stdin.\n"); return 1; }
+        input = stdin_buf;
     }
 
     // Count total lines
@@ -50,5 +53,6 @@ int main(int argc, char **argv) {
         putchar('\n');
     }
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/terser/main.c
+++ b/wasm-tools/src/terser/main.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 // Forward reference to minify_js from minify tool
 void minify_js(const char *js) {
@@ -129,13 +130,20 @@ void minify_js(const char *js) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: terser <javascript-code>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: terser <javascript-code>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
-    minify_js(argv[1]);
+    minify_js(input);
     printf("\n");
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/toml2json/main.c
+++ b/wasm-tools/src/toml2json/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 #define MAX_SECTIONS 100
 #define MAX_KEYS 1000
@@ -254,12 +255,18 @@ void print_json(void) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: toml2json <toml-data>\n");
-        return 1;
+    const char *input = (argc >= 2) ? argv[1] : NULL;
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: toml2json <toml-data>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
-    char *data = strdup(argv[1]);
+    char *data = strdup(input);
     char *line = strtok(data, "\n");
 
     while (line) {
@@ -270,5 +277,6 @@ int main(int argc, char **argv) {
     free(data);
     print_json();
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/tr/main.c
+++ b/wasm-tools/src/tr/main.c
@@ -5,7 +5,9 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 int main(int argc, char **argv) {
     int delete_mode = 0;
@@ -25,8 +27,19 @@ int main(int argc, char **argv) {
         }
     }
 
-    if (!set1 || !input || (!delete_mode && !set2)) {
+    char *stdin_buf = NULL;
+    if (!input) {
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: tr [-d] SET1 [SET2] <text>\n");
+            return 1;
+        }
+        input = stdin_buf;
+    }
+
+    if (!set1 || (!delete_mode && !set2)) {
         fprintf(stderr, "Usage: tr [-d] SET1 [SET2] <text>\n");
+        free(stdin_buf);
         return 1;
     }
 
@@ -55,5 +68,6 @@ int main(int argc, char **argv) {
         }
     }
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/uniq/main.c
+++ b/wasm-tools/src/uniq/main.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../stdin_read.h"
 
 #define MAX_LINE_LEN 4096
 
@@ -28,9 +29,14 @@ int main(int argc, char **argv) {
         }
     }
 
+    char *stdin_buf = NULL;
     if (!input) {
-        fprintf(stderr, "Usage: uniq [-c] [-d] [-u] <text>\n");
-        return 1;
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: uniq [-c] [-d] [-u] <text>\n");
+            return 1;
+        }
+        input = stdin_buf;
     }
 
     char *input_copy = strdup(input);
@@ -79,5 +85,6 @@ int main(int argc, char **argv) {
     }
 
     free(input_copy);
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/wc/main.c
+++ b/wasm-tools/src/wc/main.c
@@ -5,8 +5,10 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 int main(int argc, char **argv) {
     int count_lines = 1, count_words = 1, count_chars = 1;
@@ -34,9 +36,11 @@ int main(int argc, char **argv) {
         }
     }
 
+    char *stdin_buf = NULL;
     if (!input) {
-        fprintf(stderr, "Usage: wc [-lwc] <text>\n");
-        return 1;
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) { fprintf(stderr, "Usage: wc [-lwc] <text>\nOr pipe input via stdin.\n"); return 1; }
+        input = stdin_buf;
     }
 
     int lines = 0, words = 0, chars = 0;
@@ -61,5 +65,6 @@ int main(int argc, char **argv) {
     if (count_chars) printf("%s%d", (count_lines || count_words) ? " " : "", chars);
     printf("\n");
 
+    free(stdin_buf);
     return 0;
 }

--- a/wasm-tools/src/xmllint/main.c
+++ b/wasm-tools/src/xmllint/main.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include "../stdin_read.h"
 
 #define MAX_DEPTH 100
 
@@ -284,13 +285,6 @@ void xpath_query(XmlNode *node, const char *xpath) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: xmllint [--xpath EXPR] <xml>\n");
-        fprintf(stderr, "Options:\n");
-        fprintf(stderr, "  --xpath EXPR  Evaluate XPath expression\n");
-        return 1;
-    }
-
     const char *xpath = NULL;
     const char *xml = NULL;
 
@@ -302,15 +296,21 @@ int main(int argc, char **argv) {
         }
     }
 
+    char *stdin_buf = NULL;
     if (!xml) {
-        fprintf(stderr, "Error: No XML input provided\n");
-        return 1;
+        stdin_buf = read_all_stdin();
+        if (!stdin_buf) {
+            fprintf(stderr, "Usage: xmllint [--xpath EXPR] <xml>\nOr pipe input via stdin.\n");
+            return 1;
+        }
+        xml = stdin_buf;
     }
 
     XmlNode *root = parse_xml(xml);
 
     if (!root) {
         fprintf(stderr, "Error: Failed to parse XML\n");
+        free(stdin_buf);
         return 1;
     }
 
@@ -321,5 +321,6 @@ int main(int argc, char **argv) {
     }
 
     free_node(root);
+    free(stdin_buf);
     return 0;
 }


### PR DESCRIPTION
## Summary
This release adds stdin parameter support to WASM tools, allowing large text inputs to be passed via stdin instead of command-line arguments. It also improves the UI to display full tool output directly without requiring users to expand additional sections.

## Key Changes

### WASM Tool Manager & Registry
- Added `stdinParam` configuration option to tool manifests to specify which parameter should be sent via stdin
- Modified argument building logic to extract stdin parameters and pass them separately from CLI arguments
- Updated all 30+ built-in tools to use stdin for their primary input parameters (e.g., `input`, `token`)
- Always returns full stdout to the LLM while caching large outputs (>2000 bytes) for UI display
- Removed preview generation for large outputs since full content is always available

### WASM Tool Implementations
- Created `stdin_read.h` utility header with `read_all_stdin()` function for consistent stdin handling
- Updated all tool implementations to:
  - Accept input via stdin when not provided as command-line arguments
  - Support both positional and named argument styles with stdin
  - Properly free allocated stdin buffers
- Tools updated: awk, base64, csso, csvtool, cut, grep, head, html-minifier, jwt, markdown, md5sum, minify, sed, sha256sum, sha512sum, shfmt, sort, tail, terser, toml2json, tr, uniq, wc, xmllint, xxd, yq

### UI Improvements
- Changed tool result display from collapsed details with expandable "View Full Content" section to auto-expanded display
- Result summary now shows line count: `Output (N lines)` instead of just `Result`
- Full cached content displays directly without requiring additional expansion
- Falls back to summary info only if cache has expired
- Simplifies user experience for viewing WASM tool output

### Version
- Bumped version from 0.1.15 to 0.1.16

## Implementation Details
- The `stdinParam` field in tool manifests identifies which parameter value should be sent via stdin
- Stdin parameters are extracted before building CLI arguments, avoiding issues with large text in command lines
- The stdin reading utility handles dynamic buffer allocation and gracefully handles EOF
- All tools maintain backward compatibility - they still accept input as command-line arguments when provided

https://claude.ai/code/session_01QLrWWAuTnFwXD48iuB4uUR