### PR TITLE
fix: apply dark color scheme to checkboxes for proper dark mode contrast

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -2075,6 +2075,15 @@ dialog.permission-dialog[open] {
     color: #FFCCBC;
   }
 
+  /* Dark mode form controls - render native checkboxes with dark colors */
+  .form-checkbox {
+    color-scheme: dark;
+  }
+
+  .batch-tool-checkbox input[type="checkbox"] {
+    color-scheme: dark;
+  }
+
   /* Dark mode buttons */
   .primary-btn {
     background-color: #7A9CB8;

--- a/tests/visual/dark-mode.spec.ts
+++ b/tests/visual/dark-mode.spec.ts
@@ -157,6 +157,18 @@ test.describe('Dark Mode - Modals', () => {
     });
   });
 
+  test('notifications section checkbox renders correctly in dark mode', async ({ page }) => {
+    await page.click('#settings-btn');
+    const modal = page.locator('#settings-modal');
+    await expect(modal).toBeVisible();
+
+    const notificationsSection = page.locator('.notifications-section');
+    await expect(notificationsSection).toBeVisible();
+    await expect(notificationsSection).toHaveScreenshot('dark-notifications-section.png', {
+      animations: 'disabled',
+    });
+  });
+
   test('modal overlay displays correctly in dark mode', async ({ page }) => {
     await page.click('#settings-btn');
     await expect(page).toHaveScreenshot('dark-modal-overlay.png', {


### PR DESCRIPTION
Native checkboxes render with a white background by default, which
creates poor contrast in dark mode. Apply `color-scheme: dark` to
`.form-checkbox` and batch tool checkboxes so browsers render them
with dark-appropriate colors.

Also adds a visual regression test for the notifications section
checkbox in dark mode.

https://claude.ai/code/session_019YMVri9676o4gffNu7ALGq