### PR TITLE
feat: add Google Stitch MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "stitch": {
+      "type": "http",
+      "url": "https://stitch.googleapis.com/mcp",
+      "headers": {
+        "X-Goog-Api-Key": "${STITCH_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds .mcp.json with the Stitch MCP server endpoint using HTTP
transport. The API key is referenced via ${STITCH_API_KEY} environment
variable interpolation.

https://claude.ai/code/session_01RiRdmBD2Y5Ah6qifUBmErA