### PR TITLE
Fix directory listing to use expandable/collapsible tree structure

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -446,6 +446,50 @@ body {
   white-space: nowrap;
 }
 
+/* File Tree — Collapsible directory structure */
+.file-tree-dir {
+  border: none;
+  margin: 0;
+}
+
+.file-tree-dir > summary {
+  list-style: none;
+}
+
+.file-tree-dir > summary::-webkit-details-marker {
+  display: none;
+}
+
+.file-tree-dir-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-bottom: var(--spacing-xs);
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s ease;
+}
+
+.file-tree-dir-header:hover {
+  background: var(--color-bg);
+}
+
+.file-tree-chevron {
+  font-size: 0.6rem;
+  flex-shrink: 0;
+  color: var(--color-text-tertiary);
+  transition: transform 0.2s ease;
+}
+
+.file-tree-dir[open] > .file-tree-dir-header .file-tree-chevron {
+  transform: rotate(90deg);
+}
+
 /* Chat Area */
 .chat-area {
   flex: 1;


### PR DESCRIPTION
## Summary
- Replaces the flat file listing sidebar (which showed full paths like `backup/card.png`) with a proper expandable/collapsible directory tree using native `<details>` elements
- Directories render as collapsible nodes with rotating chevron indicators; files show only their name since the tree hierarchy conveys the path
- Uses `textContent` instead of `innerHTML` for file names, eliminating a potential XSS vector from crafted filenames
- CSS follows the existing permission-group collapsible pattern for visual consistency

## Test plan
- [ ] Open a workspace with nested directories and verify the file tree renders hierarchically
- [ ] Click directory chevrons to expand/collapse — verify smooth rotation animation
- [ ] Verify empty directories show as plain items (no expand arrow)
- [ ] Verify files at the root level display correctly without indentation
- [ ] Verify deeply nested directories (3+ levels) indent properly
- [ ] Verify sorting: directories appear before files, both sorted alphabetically
- [ ] Test with FileSystemObserver live updates — verify tree re-renders correctly when files change
- [ ] Verify dark mode styling is consistent

https://claude.ai/code/session_01S9ZUBapYhqLZ52eX13xroa