### PR TITLE
fix: eliminate iframe sandbox script execution errors with CSP defense-in-depth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "co-do",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "co-do",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.36",


### PR DESCRIPTION
The sandbox errors ("Blocked script execution in 'about:srcdoc'") persist
even with HTML escaping because Chrome internals and extensions can attempt
script injection into sandboxed frames.

Changes:
- Add `allow-scripts` to iframe sandbox alongside `allow-same-origin` so
  the sandbox itself no longer blocks and logs script execution attempts
- Add `<meta http-equiv="Content-Security-Policy" content="script-src 'none'">`
  inside the srcdoc document to prevent ANY script from executing, mitigating
  the allow-scripts + allow-same-origin sandbox escape vector
- Sanitize dangerous URL protocols (javascript:, vbscript:, data:) in marked
  link and image renderers to prevent XSS via markdown syntax

Defense layers:
1. Marked renderer escapes all raw HTML tokens
2. Link/image renderers strip dangerous URL protocols
3. CSP script-src 'none' in srcdoc blocks all script execution
4. Sandbox still restricts forms, popups, navigation, etc.

https://claude.ai/code/session_01Eo2dTA3kvjS2QJvpUGyCmg